### PR TITLE
added compression

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var app = module.exports = require('express')(),
+  compression = require('compression'),
   Cloudant = require('cloudant'),
   bodyParser = require('body-parser'),
   router = require('./lib/routes/index'),
@@ -42,6 +43,9 @@ function main() {
 
   // enable cors
   app.use(cors());   
+  
+  // gzip responses
+  app.use(compression());
   
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: false }));

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cfenv": "^1.0.3",
     "chance": "^1.0.3",
     "cloudant": "^1.4.1",
+    "compression": "^1.6.2",
     "events": "^1.1.0",
     "express": "^4.13.3",
     "morgan": "^1.6.1",


### PR DESCRIPTION
Event though Cloudant doesn't compress JSON bodies, it seems worthwhile if Envoy does. Requests from PouchDB accept gzipped responses and it transparently reduces bodies by a factor of 8 or so, so it seems like a reasonable performance boost to me.