### PR TITLE
deploy to Bluemx link - fixes issue #8

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Note: this is a proof of concept; it's not battle tested or supported in any way
 
 ## Installation
 
+
+### Deploy to Bluemix
+
+Cloudant Envoy can be deployed to Bluemix
+
+![Deploy to Bluemix](https://bluemix.net/deploy?repository=https://github.com/cloudant-labs/envoy)
+
+### Manual installation
+
 Cloudant Envoy is a Node.js application on top of the Express.js framework. To install, clone the repo and run `npm install`. The Envoy server needs admin credentials for the backing Cloudant database, and it expects the following environment variables to be set:
 
 ```bash

--- a/lib/env.js
+++ b/lib/env.js
@@ -2,9 +2,9 @@
 
 // helper function to find credentials from environment variables
 function getCredentials() {
-  var databaseName = process.env.MBAAS_DATABASE_NAME;
+  var databaseName = process.env.MBAAS_DATABASE_NAME || 'mbaas';
   if (!databaseName) {
-    throw('Missing env variable - must supply MBAAS_DATABASE_NAME');
+    console.error('Missing env variable - assuming "mbaas"');
   }
   var opts = {};
   if (process.env.VCAP_SERVICES) {

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,15 @@
+---
+declared-services:
+  cloudant-envoy-service:
+    label: cloudantNoSQLDB
+    plan: Shared
+applications:
+- name: cloudant-envoy
+  memory: 512M
+  instances: 1
+  domain: mybluemix.net
+  disk_quota: 512M
+  command: node ./bin/www
+  path: .
+  services:
+  - cloudant-envoy-service

--- a/test/env.js
+++ b/test/env.js
@@ -4,7 +4,7 @@ var assert = require('assert'),
   env = require('../lib/env.js'),
   assert = require('assert');
 
-describe('environment variable tests - Bluemix mode', function() {
+describe('environment variable tests - Bluemix mode', function(done) {
   var originalEnv;
   before(function(done) {
     originalEnv = Object.assign({}, process.env);
@@ -28,13 +28,11 @@ describe('environment variable tests - Bluemix mode', function() {
     done();
   });
 
-  // exception when missing process.env.MBAAS_DATABASE_NAME
+  // assumes mbaas when missing process.env.MBAAS_DATABASE_NAME
   it('missing MBAAS_DATABASE_NAME', function(done) {
     delete process.env.MBAAS_DATABASE_NAME;
-    assert.throws( function() {
-      env.getCredentials();
-    });
-
+    var e = env.getCredentials();
+    assert.equal(e.databaseName, 'mbaas');
     done();
   });
 


### PR DESCRIPTION
Added simple link for now - I need to test it when it reaches the master branch. I can add a fancier button that tracks the number of deployments if required. But this is MVP. I had to rework the way the environment variables work - I made it assume that a missing "MBAAS_DATABASE_NAME" meant a database name of "mbaas". This saves the Bluemix user from having to create a custom environment variable to get this to work - it finds the port number and the Cloudant config from pre-existing env variables.