### PR TITLE
Add streaming support for /db/_all_docs - Issue13

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -75,7 +75,6 @@ function createDB(callback/*(err, result)*/) {
   app.cloudant.db.create(e.databaseName, function(err, body, header) {
     // 201 response == created
     // 412 response == already exists
-    console.log(header);
     if(err || (header.statusCode !== 201 && header.statusCode !== 412)) {
       callback(err || body);
       return;

--- a/lib/routes/all-docs.js
+++ b/lib/routes/all-docs.js
@@ -25,51 +25,21 @@ router.get('/:db/_all_docs', auth.isAuthenticated, function(req, res) {
   // TODO strip these out from the response
   req.query.include_docs = true;
 
-  app.db.list(req.query, function (err, body) {
-    if (err) {
-      utils.sendError(err, res);
-      return;
-    }
-    var data = body.rows.filter(function (row) {
-      if (!row.doc[app.metaKey]) { // Skip non-meta'ed docs
-        return false;
-      }
-      var authfield = row.doc[app.metaKey].auth;
-      var accessible = authfield.users.indexOf(user.name) >= 0;
-      delete row.doc[app.metaKey];
-      return accessible;
-    });
-    body.rows = data;
-
-    // NOTE: what is the correct way to deal with the 'total_rows' part?
-    // maybe populate from a reduced view query?
-    body.total_rows = body.rows.length;
-    res.json(body);
-  });
+  app.db.list(req.query)
+    .pipe(utils.liner())
+    .pipe(utils.authRemover(user.name))
+    .pipe(res);
+    
 });
 
 router.post('/:db/_all_docs', auth.isAuthenticated, function(req, res) {
   var user = basicAuth(req);
 
-  app.db.fetch(req.body, function (err, body) {
-    if (err) {
-      utils.sendError(err, res);
-      return;
-    }
-    var data = body.rows.filter(function (row) {
-      if (!row.doc[app.metaKey]) { // Skip non-meta'ed docs
-        return false;
-      }
-      var authfield = row.doc[app.metaKey].auth;
-      var accessible = authfield.users.indexOf(user.name) >= 0;
-      delete row.doc[app.metaKey];
-      return accessible;
-    });
-    // NOTE: what is the correct way to deal with the 'total_rows' part?
-    body.rows = data;
-    body.total_rows = body.rows.length;
-    res.json(body);
-  });
+  app.db.fetch(req.body)
+    .pipe(utils.liner())
+    .pipe(utils.authRemover(user.name))
+    .pipe(res);
+  
 });
 
 module.exports = router;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,44 +46,60 @@ var writeDoc = function(db, data, req, res) {
   });
 };
 
-var stripAuth = function (obj) {
-  var addComma = false;
-  var chunk = obj;
 
-  // If the line ends with a comma, this would break JSON parsing.
-  if (obj.endsWith(',')) {
-    chunk = obj.slice(0, -1);
-    addComma = true;
-  }
-
-  try { 
-    var row = JSON.parse(chunk); 
-  } catch (e) {
-    return obj+'\n'; // An incomplete fragment: pass along as is.
-  }
-
-  // Successfully parsed a doc line. Remove auth field.
-  if (row.doc && row.doc[app.metaKey]) {
-    delete row.doc[app.metaKey];
-  } 
-  
-  // cloudant query doesn't return a .doc
-  delete row[app.metaKey]
-
-  // Repack, and add the trailling comma if required
-  var retval = JSON.stringify(row);
-  if (addComma) {
-    retval += ',';
-  }
-
-  return retval+'\n'; // Tack on line ending which was stripped by liner()
-};
 
 // stream transformer that removes auth details from documents
-var authRemover = function() {
+var authRemover = function(onlyuser) {
+  var firstRecord = true;
+  
+  
+  var stripAuth = function (obj, onlyuser) {
+    var addComma = false;
+    var chunk = obj;
+
+    // If the line ends with a comma, this would break JSON parsing.
+    if (obj.endsWith(',')) {
+      chunk = obj.slice(0, -1);
+      addComma = true;
+    }
+
+    try { 
+      var row = JSON.parse(chunk); 
+    } catch (e) {
+      return obj+'\n'; // An incomplete fragment: pass along as is.
+    }
+
+    // Successfully parsed a doc line. Remove auth field.
+    if (row.doc) {
+      if (row.doc[app.metaKey]) {
+        var meta = row.doc[app.metaKey];
+        if (onlyuser && meta.auth && meta.auth.users && 
+            meta.auth.users.indexOf(onlyuser) === -1) {
+          return '';
+        }
+        delete row.doc[app.metaKey];
+      } else {
+        // if doc has no metaKey, then it should not be returned
+        return '';
+      }
+    } 
+  
+    // cloudant query doesn't return a .doc
+    delete row[app.metaKey];
+
+    // Repack, and add the trailling comma if required
+    var retval = JSON.stringify(row);
+    if (firstRecord) {
+      firstRecord = false;
+      return retval+'';
+    } else {
+      return ',\n'+retval;
+    }
+  };
+  
   var tr = new stream.Transform({objectMode: true});
   tr._transform = function (obj, encoding, done) {
-    var data = stripAuth(obj);
+    var data = stripAuth(obj, onlyuser);
     if (data) {
       this.push(data);
     }

--- a/test/query.js
+++ b/test/query.js
@@ -40,7 +40,7 @@ describe('query', function () {
         assert(doc.i > 5);
         
         // ensure we have stripped auth information
-        assert(typeof doc[app.metaKey] == 'undefined');
+        assert(typeof doc[app.metaKey] === 'undefined');
       });
       done();
     });
@@ -65,10 +65,10 @@ describe('query', function () {
       assert(response.result === 'created');
       assert(typeof response.id === 'string');
       assert(response.name === 'testjsonindex');
-      done()
+      done();
     });
       
-  })
+  });
   
   
   it('read from json index', function (done) {
@@ -93,7 +93,7 @@ describe('query', function () {
         assert(doc.i > 5);
         
         // ensure we have stripped auth information
-        assert(typeof doc[app.metaKey] == 'undefined');
+        assert(typeof doc[app.metaKey] === 'undefined');
       });
       done();
     });
@@ -137,14 +137,14 @@ describe('query', function () {
     };
     remote.request(r, function (err, response) {
       assert(err == null);
-      assert(typeof response.warning != 'string')
+      assert(typeof response.warning !== 'string');
       assert(response.docs.length > 1);
       response.docs.forEach(function (doc) {
         // check that our query worked (docs with i > 5)
         assert(doc.i > 5);
         
         // ensure we have stripped auth information
-        assert(typeof doc[app.metaKey] == 'undefined');
+        assert(typeof doc[app.metaKey] === 'undefined');
       });
       done();
     });

--- a/test/sync.js
+++ b/test/sync.js
@@ -28,11 +28,9 @@ describe('test single user sync', function () {
     var local = new PouchDB(dbs.local);
     var remote = new PouchDB(remoteURL);
     var docs = testUtils.makeDocs(5);
-
     return remote.allDocs()
       .then(function (response) {
-        assert.equal(response.total_rows, 0);
-
+        assert.equal(response.rows.length, 0);
         return local.bulkDocs(docs);
       }).then(function () {
         return local.replicate.to(remote);
@@ -41,7 +39,7 @@ describe('test single user sync', function () {
         // on the remote side.
         return remote.allDocs();
       }).then(function (response) {
-        assert.equal(response.total_rows, docs.length);
+        assert.equal(response.rows.length, docs.length);
       });
   });
 


### PR DESCRIPTION
Changes the GET /db/_all_docs and POST /db/_all_docs to use the streaming api. We can't use the streaming method (as it is) with /db/_bulk_get because (apparently) it doesn't return one doc per line.