### PR TITLE
tidy up of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "contributors": [
     "Stefan Kruger <stefan.kruger@gmail.com>",
     "Will Holley <willholley@gmail.com>",
-    "Glynn Bird <glynn.bird@gmail.com>"
+    "Glynn Bird <glynn.bird@gmail.com>",
+    "Tom Blench",
+    "Simon Metson",
+    "Mike Rhodes"
   ],
   "keywords": [
     "backend",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,18 @@
 {
-  "name": "cds-mobile",
+  "name": "cloudant-envoy",
   "version": "0.0.0",
   "description": "A mobile backend shim to Cloudant",
-  "author": "",
+  "contributors": [
+    "Stefan Kruger <stefan.kruger@gmail.com>",
+    "Will Holley <willholley@gmail.com>",
+    "Glynn Bird <glynn.bird@gmail.com>"
+  ],
   "keywords": [
     "backend",
     "node",
     "cloudant"
   ],
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "start": "node ./bin/www",
     "jshint": "jshint -c .jshintrc lib/",
@@ -34,5 +38,18 @@
     "mocha": "2.4.5",
     "supertest": "1.2.0",
     "pouchdb": "^5.2.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cloudant-labs/envoy"
+  },
+  "bugs": {
+    "url": "https://github.com/cloudant-labs/envoy/issues"
+  },
+  "bin" : { 
+    "envoy" : "./bin/www" 
+  },
+  "engines": {
+    "node": ">=4.2.0"
   }
 }


### PR DESCRIPTION
Added
* contributors
* corrected the licence to Apache-2.0, 
* repository - used by npm (if we npm publish this) and the deployment tracker
* bugs - used by npm
* bin - allows folks to `npm install -g cloudant-envoy` and then run `envoy` from the command-line
* engines - used by Bluemix 

Modified:
* name - changed to "cloudant-envoy"