### PR TITLE
added runtime log format options - fixes issues #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,30 @@ export COUCH_HOST='https://key:passwd@account.cloudant.com'
 
 After those variables are set, you can start the Envoy server with `npm start`. Note that the port is the port that Envoy will listen to, not the port of the Cloudant server.
 
+### Environment variables
+
+* PORT - the port number Envoy will listen on. When running in Bluemix, Envoy detects the Cloud Foundry port assigned to this app automatically. When running locally, you'll need to provide your own e.g. `export PORT=8001`
+* COUCH_HOST - The URL of the Cloudant service to connected to. Not required in Bluemix, as the attached Cloudant service is detected automatically. `COUCH_HOST` is required when running locally e.g. `export COUCH_HOST='https://key:passwd@account.cloudant.com'`
+* MBAAS_DATABASE_NAME - the name of the Cloudant database to use. Defaults to `mbaas`
+* LOG_FORMAT - the type of logging to output. One of `combined`, `common`, `dev`, `short`, `tiny`, `off`. Defaults to `off`. (see https://www.npmjs.com/package/morgan)
+* DEBUG - see debugging section
+
+
+## Debugging
+
+Debugging messages are controlled by the `DEBUG` environment variable. To see detailed debugging outlining the API calls being made between Envoy and Cloudant then set the `DEBUG` environment variable to `cloudant,nano` e.g
+
+```bash
+export DEBUG=cloudant,nano
+node app.js
+```
+
+or
+
+```bash
+DEBUG=cloudant,nano node app.js
+```
+
 ## Introduction
 
 Cloudant has the potential to be an ideal backend for a mobile application. It is scalable, it syncs, and being schema-free it can cope with the frequent data changes that tend to happen in mobile development.

--- a/app.js
+++ b/app.js
@@ -10,7 +10,6 @@ var app = module.exports = require('express')(),
   events = require('events'),
   ee = new events.EventEmitter(),
   morgan = require('morgan'),
-  fs = require('fs'),
   cors = require('./lib/cors'); 
 
 // Required environment variables
@@ -23,21 +22,12 @@ app.db = cloudant.db.use(dbName);
 app.metaKey = 'com_cloudant_meta';
 app.events = ee;
 app.cloudant = cloudant;
-
 app.serverURL = env.couchHost;
 
-// Set up the logging directory
-var logDirectory = __dirname + '/logs';
-if (!fs.existsSync(logDirectory)) {
-   fs.mkdirSync(logDirectory);
+// Setup the logging format
+if (env.logFormat !== 'off') {
+  app.use(morgan(env.logFormat));
 }
-
-// Create a write stream (in append mode)
-var accessLogStream =
-  fs.createWriteStream(logDirectory + '/access.log', {flags: 'a'});
-
-// Setup the logger
-app.use(morgan('dev', {stream: accessLogStream}));
 
 function main() {
 

--- a/lib/env.js
+++ b/lib/env.js
@@ -6,7 +6,9 @@ function getCredentials() {
   if (!databaseName) {
     console.error('Missing env variable - assuming "mbaas"');
   }
-  var opts = {};
+  var opts = {
+    logFormat: process.env.LOG_FORMAT || 'off'
+  };
   if (process.env.VCAP_SERVICES) {
 
     // this will throw an exception if VCAP_SERVICES is not valid JSON
@@ -33,17 +35,15 @@ function getCredentials() {
 
   } else {
     // piecemeal environment variables
-    opts =  {
-      couchHost: process.env.COUCH_HOST,
-      databaseName: databaseName,
-      port: process.env.PORT,
-      url: 'localhost:' + process.env.PORT
-    };
+    opts.couchHost = process.env.COUCH_HOST;
+    opts.databaseName = databaseName;
+    opts.port = process.env.PORT;
+    opts.url = 'localhost:' + process.env.PORT;
     if (!opts.couchHost || !opts.port) {
       throw('Missing env variable - ' +
             'must supply COUCH_HOST & PORT');
     }
-    if(parseInt(opts.port,10).toString() !== opts.port) {
+    if (parseInt(opts.port,10).toString() !== opts.port) {
       throw new Error ('port ' + opts.port + ' must be an integer');
     }
   }


### PR DESCRIPTION
Separating logging from debugging, Morgan is great for logging. I've added a `LOG_FORMAT` environment variable that allows you to change the logging format at run time. It defaults to `off` but can be one of `combined`, `common`, `dev`, `short`, `tiny`

e.g. 

```sh
> LOG_FORMAT=combined node app
[OK]  verifyDB: database found "mbaas"
[OK]  verifySecurityDoc: permissions good
[OK]  installSystemViews: good
[OK]  main: Started app on localhost:8000
::1 - glynn [26/May/2016:18:28:27 +0000] "PUT /mbaas/c HTTP/1.1" 200 63 "-" "curl/7.43.0"
::1 - bob [26/May/2016:18:28:28 +0000] "PUT /mbaas/d HTTP/1.1" 200 63 "-" "curl/7.43.0"
```

Debugging is already enable for the Cloudant and Nano libraries, so you can switch on debugging with

```sh
DEBUG=nano,cloudant node app.js
```

To get detailed output of the interactions between Envoy and Cloudant