### PR TITLE
removed POST /db/_index endpoint - fixes issue #31

### DIFF
--- a/lib/routes/post-index.js
+++ b/lib/routes/post-index.js
@@ -12,6 +12,10 @@ var express = require('express'),
 // This creates a Cloudant Query index 
 // see https://docs.cloudant.com/cloudant_query.html#creating-an-index
 // The index is modified to add the user name into the index too.
+/*
+
+**** Removed for now - see issue #31 ****
+
 router.post('/:db/_index', auth.isAuthenticated, function(req, res) {
   
   // Authenticate the documents requested
@@ -37,6 +41,17 @@ router.post('/:db/_index', auth.isAuthenticated, function(req, res) {
     res.json(body);
   });
 
+});
+*/
+
+// don't allow the creation of indexes via Envoy API
+router.post('/:db/_index', auth.isAuthenticated, function(req, res) { 
+  var err = {
+    statusCode: 404,
+    error: 'Not Found',
+    reason: 'Not supported in Envoy'
+  };
+  return utils.sendError(err, res);
 });
 
 module.exports = router;

--- a/test/query.js
+++ b/test/query.js
@@ -45,7 +45,32 @@ describe('query', function () {
       done();
     });
   });
-  
+
+  // POST /db/_index not support so should 404
+  it('fail to create json index', function(done) {
+    // Cloudant "/db/_index" 
+    // create json index
+    var r = { 
+      url: '_index', 
+      method: 'post', 
+      body: { 
+        index: {
+          fields: ['i']
+        },
+        name: 'testjsonindex',
+        type: 'json'
+      }
+    };
+    remote.request(r, function(err, response) {
+      assert(err != null);
+      assert(err.status === 404);
+      done()
+    });
+      
+  })
+
+/* Removed index creation tests - see issue #31
+    
   it('create json index', function(done) {
     // Cloudant "/db/_index" 
     // create json index
@@ -149,5 +174,6 @@ describe('query', function () {
       done();
     });
   });
+*/ 
   
 });


### PR DESCRIPTION
* removed code that handled `POST /db/_index`
* 404'd calls to `POST /db/_index` to prevent them being handled by `POST /db/:id`
* allowed calls to `POST /db/_find` to continue as before
* altered tests to remove testing of `POST /db/_index` and to ensure that it 404s