### PR TITLE
Configurable authentication methods using Passport

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ After those variables are set, you can start the Envoy server with `npm start`. 
 * MBAAS_DATABASE_NAME - the name of the Cloudant database to use. Defaults to `mbaas`
 * LOG_FORMAT - the type of logging to output. One of `combined`, `common`, `dev`, `short`, `tiny`, `off`. Defaults to `off`. (see https://www.npmjs.com/package/morgan)
 * DEBUG - see debugging section
-
+* AUTH_STATEGY - the method used by users for authentication. Defaults to `basic`.
 
 ## Debugging
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ After those variables are set, you can start the Envoy server with `npm start`. 
 * MBAAS_DATABASE_NAME - the name of the Cloudant database to use. Defaults to `mbaas`
 * LOG_FORMAT - the type of logging to output. One of `combined`, `common`, `dev`, `short`, `tiny`, `off`. Defaults to `off`. (see https://www.npmjs.com/package/morgan)
 * DEBUG - see debugging section
-* AUTH_STATEGY - the method used by users for authentication. Defaults to `basic`.
+* AUTH_STATEGY - the method used by users for authentication. One of `basic`, `google`. Defaults to `basic`. See authentication section.
+* GOOGLE_CLIENT_ID - for Google OAuth authentication
+* GOOGLE_CLIENT_SECRET - for Google OAuth authentication
+* ENVOY_URL - for Google OAuth authentication
 
 ## Debugging
 
@@ -52,6 +55,38 @@ or
 ```bash
 DEBUG=cloudant,nano node app.js
 ```
+
+## Authentication
+
+
+### Basic
+
+By default, Envoy is configured to use the `basic` authentication stategy. This means that credentials are passed in using HTTP basic authentication e.g.
+
+```
+http://myusername:mypassword@myenvoyinstance.mybluemix.net/db/_all_docs
+```
+
+This strategy is only designed for testing Envoy as there is no real user database. As long as the supplied password is equal to `sha1(username)`, then we let you in! Here are some sample usernames and passwords you can use for testing:
+
+
+* username 'rita', password '6fe06f8d903ee0d0242c6f31b94578b2957c9752'
+* usename 'sue', password '1eac7bdcbb6c569f15ecbf5cd873a2c477888e56'
+* username 'bob', password '48181acd22b3edaebc8a447868a7df7ce629920a'
+ 
+### Google
+
+Setting the `AUTH_STRATEGY` environment variable to 'google' configures Envoy to use Google OAuth2 authentication, so users can sign up for an Envoy account using their Google account. Sign up for OAuth2 credentials from the [Google Developer Console](https://console.developers.google.com/) and use the client id and secret in environment variables e.g.:
+
+```
+export AUTH_STRATEGY=google
+export GOOGLE_CLIENT_ID="mysecretclientid825125.apps.googleusercontent.com"
+export GOOGLE_CLIENT_SECRET="myclientsecret351521"
+export ENVOY_URL="http://localhost:8000"
+node app.js
+```
+
+The `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` can be found by sign up for 
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ export ENVOY_URL="http://localhost:8000"
 node app.js
 ```
 
-The `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` can be found by sign up for 
+Then hit the `GET /_auth/google` endpoint in your browser to authenticate.
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ For OAuth authentication:
 * FACEBOOK_APP_SECRET - for Facebook OAuth authentication
 * GITHUB_CLIENT_ID - for Github OAuth authentication
 * GITHUB_CLIENT_SECRET - for Github OAuth authentication
+* TWITTER_CONSUMER_KEY - for Twitter OAuth authentication
+* TWITTER_CONSUMER_SECRET - for Twitter OAuth authentication
 
 ## Debugging
 
@@ -75,7 +77,6 @@ http://myusername:mypassword@myenvoyinstance.mybluemix.net/db/_all_docs
 ```
 
 This strategy is only designed for testing Envoy as there is no real user database. As long as the supplied password is equal to `sha1(username)`, then we let you in! Here are some sample usernames and passwords you can use for testing:
-
 
 * username 'rita', password '6fe06f8d903ee0d0242c6f31b94578b2957c9752'
 * usename 'sue', password '1eac7bdcbb6c569f15ecbf5cd873a2c477888e56'
@@ -122,6 +123,23 @@ node app.js
 ```
 
 Then hit the `GET /_auth/github` endpoint in your browser to authenticate.
+
+
+### Twitter
+
+Setting the `AUTH_STRATEGY` environment variable to 'twitter' configures Envoy to use Twitter for authentication, so users can sign up for an Envoy account using their Facebook account. Sign up for OAuth2 credentials from the [Twitter Developers page](https://apps.twitter.com/app/new), making sure you set the Authorization Callback URL to `<your Envoy URL>/_auth/github/callback` (localhost not allowed) and use the consumer key and secret in environment variables e.g.:
+
+```
+export AUTH_STRATEGY=twitter
+export TWITTER_CONSUMER_KEY="myclientid825125"
+export TWITTER_CONSUMER_SECRET="myclientsecret351521"
+export ENVOY_URL="http://mydomain.name.com:8000"
+node app.js
+```
+
+Then hit the `GET /_auth/github` endpoint in your browser to authenticate.
+https://apps.twitter.com/app/new
+
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Note: this is a proof of concept; it's not battle tested or supported in any way
 
 ### Deploy to Bluemix
 
-he fastest way to deploy *Cloudant Envoy* to Bluemix is to click the **Deploy to Bluemix** button below.
+The fastest way to deploy *Cloudant Envoy* to Bluemix is to click the **Deploy to Bluemix** button below.
 
-![Deploy to Bluemix](https://deployment-tracker.mybluemix.net/stats/34c200255dfd02ea539780bb433da951/button.svg)](https://bluemix.net/deploy?repository=https://github.com/cloudant-labs/envoy)
+[![Deploy to Bluemix](https://deployment-tracker.mybluemix.net/stats/34c200255dfd02ea539780bb433da951/button.svg)](https://bluemix.net/deploy?repository=https://github.com/cloudant-labs/envoy)
 
 **Don't have a Bluemix account?** If you haven't already, you'll be prompted to sign up for a Bluemix account when you click the button.  Sign up, verify your email address, then return here and click the the **Deploy to Bluemix** button again. Your new credentials let you deploy to the platform and also to code online with Bluemix and Git. If you have questions about working in Bluemix, find answers in the [Bluemix Docs](https://www.ng.bluemix.net/docs/).
 
@@ -36,10 +36,15 @@ After those variables are set, you can start the Envoy server with `npm start`. 
 * MBAAS_DATABASE_NAME - the name of the Cloudant database to use. Defaults to `mbaas`
 * LOG_FORMAT - the type of logging to output. One of `combined`, `common`, `dev`, `short`, `tiny`, `off`. Defaults to `off`. (see https://www.npmjs.com/package/morgan)
 * DEBUG - see debugging section
+
+For OAuth authentication:
+
 * AUTH_STATEGY - the method used by users for authentication. One of `basic`, `google`. Defaults to `basic`. See authentication section.
+* ENVOY_URL - for Google/Facebook OAuth authentication
 * GOOGLE_CLIENT_ID - for Google OAuth authentication
 * GOOGLE_CLIENT_SECRET - for Google OAuth authentication
-* ENVOY_URL - for Google OAuth authentication
+* FACEBOOK_APP_ID - for Facebook OAuth authentication
+* FACEBOOK_APP_SECRET - for Facebook OAuth authentication
 
 ## Debugging
 
@@ -87,6 +92,20 @@ node app.js
 ```
 
 Then hit the `GET /_auth/google` endpoint in your browser to authenticate.
+
+### Facebook
+
+Setting the `AUTH_STRATEGY` environment variable to 'facebook' configures Envoy to use Facebook for authentication, so users can sign up for an Envoy account using their Facebook account. Sign up for OAuth2 credentials from the [Facebook Developer Dashboard](https://developers.facebook.com/) and use the app id and secret in environment variables e.g.:
+
+```
+export AUTH_STRATEGY=facebook
+export FACEBOOK_APP_ID="mysecretclientid825125.apps.googleusercontent.com"
+export FACEBOOK_APP_SECRET="myclientsecret351521"
+export ENVOY_URL="http://localhost:8000"
+node app.js
+```
+
+Then hit the `GET /_auth/facebook` endpoint in your browser to authenticate.
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ For OAuth authentication:
 * GOOGLE_CLIENT_SECRET - for Google OAuth authentication
 * FACEBOOK_APP_ID - for Facebook OAuth authentication
 * FACEBOOK_APP_SECRET - for Facebook OAuth authentication
+* GITHUB_CLIENT_ID - for Github OAuth authentication
+* GITHUB_CLIENT_SECRET - for Github OAuth authentication
 
 ## Debugging
 
@@ -99,13 +101,27 @@ Setting the `AUTH_STRATEGY` environment variable to 'facebook' configures Envoy 
 
 ```
 export AUTH_STRATEGY=facebook
-export FACEBOOK_APP_ID="mysecretclientid825125.apps.googleusercontent.com"
+export FACEBOOK_APP_ID="myclientid825125"
 export FACEBOOK_APP_SECRET="myclientsecret351521"
 export ENVOY_URL="http://localhost:8000"
 node app.js
 ```
 
 Then hit the `GET /_auth/facebook` endpoint in your browser to authenticate.
+
+### GitHub
+
+Setting the `AUTH_STRATEGY` environment variable to 'github' configures Envoy to use GitHub for authentication, so users can sign up for an Envoy account using their Facebook account. Sign up for OAuth2 credentials from the [Git Hub Developers page](https://github.com/settings/applications/new), making sure you set the Authorization Callback URL to `<your Envoy URL>/_auth/github/callback` and use the app id and secret in environment variables e.g.:
+
+```
+export AUTH_STRATEGY=github
+export GITHUB_CLIENT_ID="myclientid825125"
+export GITHUB_CLIENT_SECRET="myclientsecret351521"
+export ENVOY_URL="http://localhost:8000"
+node app.js
+```
+
+Then hit the `GET /_auth/github` endpoint in your browser to authenticate.
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ After those variables are set, you can start the Envoy server with `npm start`. 
 
 For OAuth authentication:
 
-* AUTH_STATEGY - the method used by users for authentication. One of `basic`, `google`. Defaults to `basic`. See authentication section.
+* AUTH_STATEGY - the method used by users for authentication. One of `basic`, `google`, `facebook`, `github`. Defaults to `basic`. See authentication section.
 * ENVOY_URL - for Google/Facebook OAuth authentication
 * GOOGLE_CLIENT_ID - for Google OAuth authentication
 * GOOGLE_CLIENT_SECRET - for Google OAuth authentication

--- a/app.js
+++ b/app.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var app = module.exports = require('express')(),
+  session = require('express-session'),
+  passport = require('passport'),
   compression = require('compression'),
   Cloudant = require('cloudant'),
   bodyParser = require('body-parser'),
@@ -24,6 +26,7 @@ app.events = ee;
 app.cloudant = cloudant;
 app.serverURL = env.couchHost;
 
+
 // Setup the logging format
 if (env.logFormat !== 'off') {
   app.use(morgan(env.logFormat));
@@ -40,6 +43,15 @@ function main() {
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: false }));
 
+  // passport for auth
+  app.use(session({ secret: 'envoy', maxAge: 60*60*24}));
+  app.use(passport.initialize());
+  app.use(passport.session());
+  
+  // authentication routes
+  app.use('/', require('./lib/auth').router);
+  
+  // API routes
   app.use('/', router);
 
   // Catch 404 and forward to error handler.

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,19 +1,5 @@
 'use strict';
 
-var passport = require('passport'),
-  utils = require('./utils'),
-  BasicStrategy = require('passport-http').BasicStrategy;
-
-passport.use(new BasicStrategy(
-  function(username, password, done) {
-    if (password === utils.sha1(username)) {
-      return done(null, { username: username});
-    } else {
-      return done(null, false);
-    }
-  }
-));
-
-module.exports = passport.authenticate('basic', { session: false });
-
-
+var strategy = process.env.AUTH_STRATEGY || 'basic';
+console.log('[OK]  auth strategy: ' + strategy);
+module.exports = require('./auth/' + strategy); 

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,33 +1,19 @@
 'use strict';
 
-var basicAuth = require('basic-auth'),
-  crypto = require('crypto');
+var passport = require('passport'),
+  utils = require('./utils'),
+  BasicStrategy = require('passport-http').BasicStrategy;
 
-function unauthorized(res) {
-  res.set('WWW-Authenticate', 'Basic realm=Authorization Required');
-  return res.sendStatus(401);
-}
-
-// Authenticator - shared middleware
-function auth(req, res, next) {
-  var user = basicAuth(req);
-  if (!user || !user.name || !user.pass) {
-    return unauthorized(res);
+passport.use(new BasicStrategy(
+  function(username, password, done) {
+    if (password === utils.sha1(username)) {
+      return done(null, { username: username});
+    } else {
+      return done(null, false);
+    }
   }
-  // TODO: Call into for realz auth here: this is OBVIOUSLY not real.
-  if (user.pass === sha1(user.name)) {
-    return next();
-  }
+));
 
-  return unauthorized(res);
-}
+module.exports = passport.authenticate('basic', { session: false });
 
-function sha1(string) {
-  return crypto.createHash('sha1').update(string).digest('hex');
-}
 
-module.exports = {
-  isAuthenticated: auth,
-  unauthorized: unauthorized,
-  sha1: sha1
-};

--- a/lib/auth/basic.js
+++ b/lib/auth/basic.js
@@ -1,0 +1,22 @@
+'use strict';
+
+// warning to remind people they are using non-production code
+console.log('WARNING: This is for demo and test purposes only');
+
+var passport = require('passport'),
+  utils = require('../utils'),
+  BasicStrategy = require('passport-http').BasicStrategy;
+
+passport.use(new BasicStrategy(
+  function(username, password, done) {
+    if (password === utils.sha1(username)) {
+      return done(null, { username: username});
+    } else {
+      return done(null, false);
+    }
+  }
+));
+
+module.exports = passport.authenticate('basic', { session: false });
+
+

--- a/lib/auth/basic.js
+++ b/lib/auth/basic.js
@@ -38,8 +38,7 @@ router.get('/_auth',  function(req, res, next) {
     var obj = {
       loggedin: true,
       username: req.session.passport.user.username,
-      displayName: req.session.passport.user.username    
-      
+      displayName: req.session.passport.user.username       
     }
     res.send(obj);
   } else {

--- a/lib/auth/basic.js
+++ b/lib/auth/basic.js
@@ -5,6 +5,8 @@ console.log('WARNING: This is for demo and test purposes only');
 
 var passport = require('passport'),
   utils = require('../utils'),
+  express = require('express'),
+	router = express.Router(),
   BasicStrategy = require('passport-http').BasicStrategy;
 
 passport.use(new BasicStrategy(
@@ -17,6 +19,24 @@ passport.use(new BasicStrategy(
   }
 ));
 
-module.exports = passport.authenticate('basic', { session: false });
+// the passport authenticator middleware
+var authenticator = passport.authenticate('basic', { session: false });
+
+// our middleware that injects the username into 'req'
+var isAuthenticated = function() { 
+  return function (req, res, next) {
+    authenticator(req, res, function() {
+      req.username="jimmy";
+      console.log(req);
+      console.log(req.username);
+      next();
+    });
+  }
+};
+
+module.exports = {
+  isAuthenticated: function() { return authenticator; },
+  router: router
+};
 
 

--- a/lib/auth/basic.js
+++ b/lib/auth/basic.js
@@ -20,22 +20,45 @@ passport.use(new BasicStrategy(
 ));
 
 // the passport authenticator middleware
-var authenticator = passport.authenticate('basic', { session: false });
+var authenticator = passport.authenticate('basic', { session: true });
+
+
+passport.serializeUser(function(user, done) {
+  done(null, user);
+});
+
+passport.deserializeUser(function(id, done) {
+   done(null, id);
+});
+
+
+// authentication status
+router.get('/_auth',  function(req, res, next) {
+  if (req.session.passport && req.session.passport.user) {
+    var obj = {
+      loggedin: true,
+      username: req.session.passport.user.username,
+      displayName: req.session.passport.user.username    
+      
+    }
+    res.send(obj);
+  } else {
+    res.status(403).send({ loggedin: false, path: null});
+  }
+});
 
 // our middleware that injects the username into 'req'
 var isAuthenticated = function() { 
   return function (req, res, next) {
     authenticator(req, res, function() {
-      req.username="jimmy";
-      console.log(req);
-      console.log(req.username);
+      req.username=req.session.passport.user.username;
       next();
     });
   }
 };
 
 module.exports = {
-  isAuthenticated: function() { return authenticator; },
+  isAuthenticated: isAuthenticated,
   router: router
 };
 

--- a/lib/auth/facebook.js
+++ b/lib/auth/facebook.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// check for mandatory env variables
+var mandatory = ['FACEBOOK_APP_ID','FACEBOOK_APP_SECRET','ENVOY_URL'];
+for (var i in mandatory) {
+  if (!process.env[mandatory[i]]) {
+    throw('Facebook auth strategy requires env variable - ' + mandatory[i]);
+  }
+}
+
+var FACEBOOK_APP_ID = process.env.FACEBOOK_APP_ID;
+var FACEBOOK_APP_SECRET = process.env.FACEBOOK_APP_SECRET;
+var AUTH_STUB = '/_auth/facebook';
+var CALLBACK_PATH = AUTH_STUB + '/callback';
+var FAIL_PATH = AUTH_STUB + '/fail';
+var CALLBACK_URL = process.env.ENVOY_URL + CALLBACK_PATH;
+
+
+var passport = require('passport'),
+  url = require('url'),
+  utils = require('../utils'),
+  express = require('express'),
+	router = express.Router(),
+  FacebookStrategy = require('passport-facebook').Strategy;
+
+passport.use(new FacebookStrategy({
+    clientID: FACEBOOK_APP_ID,
+    clientSecret: FACEBOOK_APP_SECRET,
+    callbackURL: CALLBACK_URL
+  },
+  function(accessToken, refreshToken, profile, done) {
+    done(null, profile);
+  }
+));
+
+passport.serializeUser(function(user, done) {
+  done(null, user);
+});
+
+passport.deserializeUser(function(id, done) {
+   done(null, id);
+});
+
+// authentication start point
+router.get(AUTH_STUB, passport.authenticate('facebook'));
+
+// success callback
+router.get(CALLBACK_PATH, 
+           passport.authenticate('facebook'),
+           function(req, res) {
+             res.redirect('/');
+           }
+);
+
+
+// authentication fail point
+router.get(FAIL_PATH,  function(req, res, next) {
+  res.send('Auth fail')
+});
+
+var isAuthenticated = function() { 
+  return function (req, res, next) {
+        
+    if (req.session.passport && 
+        req.session.passport.user && 
+        req.session.passport.user.id) {
+
+      // store the user identifier in the request
+      req.user = {
+        username: req.session.passport.user.id,
+        displayName: req.session.passport.user.name
+      };
+      
+      // call the next thing in the chain
+      next();
+      
+    } else {
+      utils.unauthorized(res);
+    }
+  }
+}
+  
+module.exports = {
+  isAuthenticated: isAuthenticated,
+  router: router
+};
+
+
+
+

--- a/lib/auth/facebook.js
+++ b/lib/auth/facebook.js
@@ -48,7 +48,7 @@ router.get(AUTH_STUB, passport.authenticate('facebook'));
 router.get(CALLBACK_PATH, 
            passport.authenticate('facebook'),
            function(req, res) {
-             res.redirect('/');
+             res.redirect('/_auth');
            }
 );
 
@@ -56,6 +56,20 @@ router.get(CALLBACK_PATH,
 // authentication fail point
 router.get(FAIL_PATH,  function(req, res, next) {
   res.send('Auth fail')
+});
+
+// authentication status
+router.get('/_auth',  function(req, res, next) {
+  if (req.session.passport && req.session.passport.user) {
+    var obj = {
+      loggedin: true,
+      username: req.session.passport.user.id,
+      displayName: req.session.passport.user.displayName    
+    }
+    res.send(obj);
+  } else {
+    res.status(403).send({ loggedin: false, path: AUTH_STUB});
+  }
 });
 
 var isAuthenticated = function() { 
@@ -68,7 +82,7 @@ var isAuthenticated = function() {
       // store the user identifier in the request
       req.user = {
         username: req.session.passport.user.id,
-        displayName: req.session.passport.user.name
+        displayName: req.session.passport.displayName
       };
       
       // call the next thing in the chain

--- a/lib/auth/github.js
+++ b/lib/auth/github.js
@@ -48,13 +48,27 @@ router.get(AUTH_STUB, passport.authenticate('github'));
 router.get(CALLBACK_PATH, 
            passport.authenticate('github'),
            function(req, res) {
-             res.redirect('/');
+             res.redirect('/_auth');
            }
 );
 
 // authentication fail point
 router.get(FAIL_PATH,  function(req, res, next) {
   res.send('Auth fail')
+});
+
+// authentication status
+router.get('/_auth',  function(req, res, next) {
+  if (req.session.passport && req.session.passport.user) {
+    var obj = {
+      loggedin: true,
+      username: req.session.passport.user.id,
+      displayName: req.session.passport.user.username    
+    }
+    res.send(obj);
+  } else {
+    res.status(403).send({ loggedin: false, path: AUTH_STUB});
+  }
 });
 
 var isAuthenticated = function() { 
@@ -67,7 +81,7 @@ var isAuthenticated = function() {
       // store the user identifier in the request
       req.user = {
         username: req.session.passport.user.id,
-        displayName: req.session.passport.user.login
+        displayName: req.session.passport.user.username
       };
       
       // call the next thing in the chain

--- a/lib/auth/github.js
+++ b/lib/auth/github.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// check for mandatory env variables
+var mandatory = ['GITHUB_CLIENT_ID','GITHUB_CLIENT_SECRET','ENVOY_URL'];
+for (var i in mandatory) {
+  if (!process.env[mandatory[i]]) {
+    throw('Github auth strategy requires env variable - ' + mandatory[i]);
+  }
+}
+
+var GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
+var GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
+var AUTH_STUB = '/_auth/github';
+var CALLBACK_PATH = AUTH_STUB + '/callback';
+var FAIL_PATH = AUTH_STUB + '/fail';
+var CALLBACK_URL = process.env.ENVOY_URL + CALLBACK_PATH;
+
+
+var passport = require('passport'),
+  url = require('url'),
+  utils = require('../utils'),
+  express = require('express'),
+	router = express.Router(),
+  GitHubStrategy = require('passport-github2').Strategy;
+
+passport.use(new GitHubStrategy({
+    clientID: GITHUB_CLIENT_ID,
+    clientSecret: GITHUB_CLIENT_SECRET,
+    callbackURL: CALLBACK_URL
+  },
+  function(accessToken, refreshToken, profile, done) {
+    done(null, profile);
+  }
+));
+
+passport.serializeUser(function(user, done) {
+  done(null, user);
+});
+
+passport.deserializeUser(function(id, done) {
+   done(null, id);
+});
+
+// authentication start point
+router.get(AUTH_STUB, passport.authenticate('github'));
+
+// success callback
+router.get(CALLBACK_PATH, 
+           passport.authenticate('github'),
+           function(req, res) {
+             res.redirect('/');
+           }
+);
+
+// authentication fail point
+router.get(FAIL_PATH,  function(req, res, next) {
+  res.send('Auth fail')
+});
+
+var isAuthenticated = function() { 
+  return function (req, res, next) {    
+    
+    if (req.session.passport && 
+        req.session.passport.user && 
+        req.session.passport.user.id) {
+
+      // store the user identifier in the request
+      req.user = {
+        username: req.session.passport.user.id,
+        displayName: req.session.passport.user.login
+      };
+      
+      // call the next thing in the chain
+      next();
+      
+    } else {
+      utils.unauthorized(res);
+    }
+  }
+}
+  
+module.exports = {
+  isAuthenticated: isAuthenticated,
+  router: router
+};
+
+
+
+

--- a/lib/auth/google.js
+++ b/lib/auth/google.js
@@ -49,7 +49,7 @@ router.get(AUTH_STUB, passport.authenticate('google'));
 router.get(CALLBACK_PATH, 
            passport.authenticate('google'),
            function(req, res) {
-             res.redirect('/');
+             res.redirect('/_auth');
            }
 );
 
@@ -57,6 +57,20 @@ router.get(CALLBACK_PATH,
 // authentication fail point
 router.get(FAIL_PATH,  function(req, res, next) {
   res.send('Auth fail')
+});
+
+// authentication status
+router.get('/_auth',  function(req, res, next) {
+  if (req.session.passport && req.session.passport.user) {
+    var obj = {
+      loggedin: true,
+      username: req.session.passport.user.id,
+      displayName: req.session.passport.user.displayName    
+    }
+    res.send(obj);
+  } else {
+    res.status(403).send({ loggedin: false, path: AUTH_STUB});
+  }
 });
 
 var isAuthenticated = function() { 

--- a/lib/auth/google.js
+++ b/lib/auth/google.js
@@ -1,0 +1,91 @@
+'use strict';
+
+// check for mandatory env variables
+var mandatory = ['GOOGLE_CLIENT_ID','GOOGLE_CLIENT_SECRET','ENVOY_URL'];
+for (var i in mandatory) {
+  if (!process.env[mandatory[i]]) {
+    throw('Google auth strategy requires env variable - ' + mandatory[i]);
+  }
+}
+
+var GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;
+var GOOGLE_CLIENT_SECRET = process.env.GOOGLE_CLIENT_SECRET;
+var AUTH_STUB = '/_auth/google';
+var CALLBACK_PATH = AUTH_STUB + '/callback';
+var FAIL_PATH = AUTH_STUB + '/fail';
+var CALLBACK_URL = process.env.ENVOY_URL + CALLBACK_PATH;
+
+
+var passport = require('passport'),
+  url = require('url'),
+  utils = require('../utils'),
+  express = require('express'),
+	router = express.Router(),
+  GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
+
+passport.use(new GoogleStrategy({
+    clientID: GOOGLE_CLIENT_ID,
+    clientSecret: GOOGLE_CLIENT_SECRET,
+    callbackURL: CALLBACK_URL,
+    scope: 'https://www.googleapis.com/auth/plus.login'
+  },
+  function(accessToken, refreshToken, profile, done) {
+    done(null, profile);
+  }
+));
+
+passport.serializeUser(function(user, done) {
+  done(null, user);
+});
+
+passport.deserializeUser(function(id, done) {
+   done(null, id);
+});
+
+// authentication start point
+router.get(AUTH_STUB, passport.authenticate('google'));
+
+// success callback
+router.get(CALLBACK_PATH, 
+           passport.authenticate('google'),
+           function(req, res) {
+             res.redirect('/');
+           }
+);
+
+
+// authentication fail point
+router.get(FAIL_PATH,  function(req, res, next) {
+  res.send('Auth fail')
+});
+
+var isAuthenticated = function() { 
+  return function (req, res, next) {
+    
+    if (req.session.passport && 
+        req.session.passport.user && 
+        req.session.passport.user.id) {
+
+      // store the user identifier in the request
+      req.user = {
+        username: req.session.passport.user.id,
+        displayName: req.session.passport.user.displayName
+      };
+      
+      // call the next thing in the chain
+      next();
+      
+    } else {
+      utils.unauthorized(res);
+    }
+  }
+}
+  
+module.exports = {
+  isAuthenticated: isAuthenticated,
+  router: router
+};
+
+
+
+

--- a/lib/auth/twitter.js
+++ b/lib/auth/twitter.js
@@ -1,0 +1,89 @@
+'use strict';
+
+// check for mandatory env variables
+var mandatory = ['TWITTER_CONSUMER_KEY','TWITTER_CONSUMER_SECRET','ENVOY_URL'];
+for (var i in mandatory) {
+  if (!process.env[mandatory[i]]) {
+    throw('Twitter auth strategy requires env variable - ' + mandatory[i]);
+  }
+}
+
+var TWITTER_CONSUMER_KEY = process.env.TWITTER_CONSUMER_KEY;
+var TWITTER_CONSUMER_SECRET = process.env.TWITTER_CONSUMER_SECRET;
+var AUTH_STUB = '/_auth/twitter';
+var CALLBACK_PATH = AUTH_STUB + '/callback';
+var FAIL_PATH = AUTH_STUB + '/fail';
+var CALLBACK_URL = process.env.ENVOY_URL + CALLBACK_PATH;
+
+
+var passport = require('passport'),
+  url = require('url'),
+  utils = require('../utils'),
+  express = require('express'),
+	router = express.Router(),
+  TwitterStrategy = require('passport-twitter').Strategy;
+
+passport.use(new TwitterStrategy({
+    consumerKey: TWITTER_CONSUMER_KEY,
+    consumerSecret: TWITTER_CONSUMER_SECRET,
+    callbackURL: CALLBACK_URL
+  },
+  function(accessToken, refreshToken, profile, done) {
+    done(null, profile);
+  }
+));
+
+passport.serializeUser(function(user, done) {
+  done(null, user);
+});
+
+passport.deserializeUser(function(id, done) {
+   done(null, id);
+});
+
+// authentication start point
+router.get(AUTH_STUB, passport.authenticate('twitter'));
+
+// success callback
+router.get(CALLBACK_PATH, 
+           passport.authenticate('twitter'),
+           function(req, res) {
+             res.redirect('/');
+           }
+);
+
+// authentication fail point
+router.get(FAIL_PATH,  function(req, res, next) {
+  res.send('Auth fail')
+});
+
+var isAuthenticated = function() { 
+  return function (req, res, next) {    
+    
+    if (req.session.passport && 
+        req.session.passport.user && 
+        req.session.passport.user.id) {
+
+      // store the user identifier in the request
+      req.user = {
+        username: req.session.passport.user.id,
+        displayName: req.session.passport.user.screen_name
+      };
+      
+      // call the next thing in the chain
+      next();
+      
+    } else {
+      utils.unauthorized(res);
+    }
+  }
+}
+  
+module.exports = {
+  isAuthenticated: isAuthenticated,
+  router: router
+};
+
+
+
+

--- a/lib/auth/twitter.js
+++ b/lib/auth/twitter.js
@@ -48,13 +48,27 @@ router.get(AUTH_STUB, passport.authenticate('twitter'));
 router.get(CALLBACK_PATH, 
            passport.authenticate('twitter'),
            function(req, res) {
-             res.redirect('/');
+             res.redirect('/_auth');
            }
 );
 
 // authentication fail point
 router.get(FAIL_PATH,  function(req, res, next) {
   res.send('Auth fail')
+});
+
+// authentication status
+router.get('/_auth',  function(req, res, next) {
+  if (req.session.passport && req.session.passport.user) {
+    var obj = {
+      loggedin: true,
+      username: req.session.passport.user.id,
+      displayName: req.session.passport.user.username
+    }
+    res.send(obj);
+  } else {
+    res.status(403).send({ loggedin: false, path: AUTH_STUB});
+  }
 });
 
 var isAuthenticated = function() { 
@@ -67,7 +81,7 @@ var isAuthenticated = function() {
       // store the user identifier in the request
       req.user = {
         username: req.session.passport.user.id,
-        displayName: req.session.passport.user.screen_name
+        displayName: req.session.passport.user.username
       };
       
       // call the next thing in the chain

--- a/lib/routes/all-docs.js
+++ b/lib/routes/all-docs.js
@@ -13,7 +13,7 @@ var express = require('express'),
   utils = require('../utils'),
   auth = require('../auth');
 
-router.get('/:db/_all_docs', auth.isAuthenticated, function(req, res) {
+router.get('/:db/_all_docs', auth, function(req, res) {
   var user = basicAuth(req);
 
   // Workaround for small bug in nano to avoid double-encoding
@@ -32,7 +32,7 @@ router.get('/:db/_all_docs', auth.isAuthenticated, function(req, res) {
     
 });
 
-router.post('/:db/_all_docs', auth.isAuthenticated, function(req, res) {
+router.post('/:db/_all_docs', auth, function(req, res) {
   var user = basicAuth(req);
 
   app.db.fetch(req.body)

--- a/lib/routes/all-docs.js
+++ b/lib/routes/all-docs.js
@@ -9,13 +9,11 @@
 var express = require('express'),
   router = express.Router(),
   app = require('../../app'),
-  basicAuth = require('basic-auth'),
   utils = require('../utils'),
   auth = require('../auth');
 
-router.get('/:db/_all_docs', auth, function(req, res) {
-  var user = basicAuth(req);
-
+router.get('/:db/_all_docs', auth.isAuthenticated(), function(req, res) {
+ 
   // Workaround for small bug in nano to avoid double-encoding
   if (req.query.keys) {
     req.query.keys = JSON.parse(req.query.keys);
@@ -27,17 +25,15 @@ router.get('/:db/_all_docs', auth, function(req, res) {
 
   app.db.list(req.query)
     .pipe(utils.liner())
-    .pipe(utils.authRemover(user.name))
+    .pipe(utils.authRemover(req.user.username))
     .pipe(res);
     
 });
 
-router.post('/:db/_all_docs', auth, function(req, res) {
-  var user = basicAuth(req);
-
+router.post('/:db/_all_docs', auth.isAuthenticated(), function(req, res) {
   app.db.fetch(req.body)
     .pipe(utils.liner())
-    .pipe(utils.authRemover(user.name))
+    .pipe(utils.authRemover(req.user.username))
     .pipe(res);
   
 });

--- a/lib/routes/bulk-docs.js
+++ b/lib/routes/bulk-docs.js
@@ -9,7 +9,7 @@ var express = require('express'),
 
 // _bulk_docs
 
-router.post('/:db/_bulk_docs', auth.isAuthenticated, function(req, res) {
+router.post('/:db/_bulk_docs', auth, function(req, res) {
   // This is a special PouchDB-case. Although it could be handled below,
   // it's factored out to avoid an extra round trip.
   if (req.body.docs && req.body.docs.length === 1 &&

--- a/lib/routes/bulk-docs.js
+++ b/lib/routes/bulk-docs.js
@@ -3,13 +3,12 @@
 var express = require('express'),
   router = express.Router(),
   app = require('../../app'),
-  basicAuth = require('basic-auth'),
   utils = require('../utils'),
   auth = require('../auth');
 
 // _bulk_docs
 
-router.post('/:db/_bulk_docs', auth, function(req, res) {
+router.post('/:db/_bulk_docs', auth.isAuthenticated(), function(req, res) {
   // This is a special PouchDB-case. Although it could be handled below,
   // it's factored out to avoid an extra round trip.
   if (req.body.docs && req.body.docs.length === 1 &&
@@ -27,8 +26,8 @@ router.post('/:db/_bulk_docs', auth, function(req, res) {
   var newEdits = 
     typeof req.body.new_edits === 'undefined' ? true : req.body.new_edits;
 
-  var user = basicAuth(req);
-  var newDocAuth = {auth: {users:[user.name], groups:[]}};
+
+  var newDocAuth = {auth: {users:[req.user.username], groups:[]}};
 
   // Iterate through docs, gathering ids where given
   var doclist = req.body.docs.reduceRight(function(acc, doc) {
@@ -76,7 +75,7 @@ router.post('/:db/_bulk_docs', auth, function(req, res) {
         acc.new.push(newdoc);
       } else if (row.doc && row.doc[app.metaKey]) {
         var authdata = row.doc[app.metaKey].auth;
-        if (authdata.users.indexOf(user.name) >= 0) { // Accessible!
+        if (authdata.users.indexOf(req.user.username) >= 0) { // Accessible!
           var doc = acc.byId[row.doc._id]; // Grab doc from original query
           doc[app.metaKey] = {auth: authdata};     // Add the authdata
           acc.good.push(doc);

--- a/lib/routes/bulk-get.js
+++ b/lib/routes/bulk-get.js
@@ -23,10 +23,11 @@
 var express = require('express'),
   router = express.Router(),
   app = require('../../app'),
+  auth = require('../auth'),
   utils = require('../utils');
 
 // Pouch does this to check it exists
-router.get('/:db/_bulk_get', function(req, res) {
+router.get('/:db/_bulk_get', auth.isAuthenticated(), function(req, res) {
   app.cloudant.request({
     db: app.dbName,
     qs: req.query || {},
@@ -34,7 +35,7 @@ router.get('/:db/_bulk_get', function(req, res) {
   }).pipe(res);
 });
 
-router.post('/:db/_bulk_get', function(req, res) {
+router.post('/:db/_bulk_get', auth.isAuthenticated(), function(req, res) {
   app.cloudant.request({
     db: app.dbName,
     qs: req.query || {},
@@ -55,7 +56,7 @@ router.post('/:db/_bulk_get', function(req, res) {
       // making the filter selection based on the first only.
       if (row.docs && row.docs[0].ok && row.docs[0].ok[app.metaKey]) {
         var authfield = row.docs[0].ok[app.metaKey].auth;
-        return authfield.users.indexOf(user.name) >= 0;
+        return authfield.users.indexOf(req.user.username) >= 0;
       }
       return false;
     }).map(function (row) {

--- a/lib/routes/bulk-get.js
+++ b/lib/routes/bulk-get.js
@@ -23,8 +23,7 @@
 var express = require('express'),
   router = express.Router(),
   app = require('../../app'),
-  utils = require('../utils'),
-  basicAuth = require('basic-auth');
+  utils = require('../utils');
 
 // Pouch does this to check it exists
 router.get('/:db/_bulk_get', function(req, res) {
@@ -36,7 +35,6 @@ router.get('/:db/_bulk_get', function(req, res) {
 });
 
 router.post('/:db/_bulk_get', function(req, res) {
-  var user = basicAuth(req);
   app.cloudant.request({
     db: app.dbName,
     qs: req.query || {},

--- a/lib/routes/changes.js
+++ b/lib/routes/changes.js
@@ -3,14 +3,12 @@
 var express = require('express'),
   router = express.Router(),
   app = require('../../app'),
-  basicAuth = require('basic-auth'),
   auth = require('../auth'),
   utils = require('../utils'),
   stream = require('stream');
 
 // _changes
-router.get('/:db/_changes', auth, function(req, res) {
-  var user = basicAuth(req);
+router.get('/:db/_changes', auth.isAuthenticated(), function(req, res) {
   var query = req.query || {};
   if (query.filter) {
     res.status(401).send({

--- a/lib/routes/changes.js
+++ b/lib/routes/changes.js
@@ -24,7 +24,7 @@ router.get('/:db/_changes', auth.isAuthenticated(), function(req, res) {
                    selector: { 
                     'com_cloudant_meta.auth.users': { 
                        '$elemMatch' : { 
-                         '$eq': user.name
+                         '$eq': req.user.username
                        }
                      }
                    }

--- a/lib/routes/changes.js
+++ b/lib/routes/changes.js
@@ -9,7 +9,7 @@ var express = require('express'),
   stream = require('stream');
 
 // _changes
-router.get('/:db/_changes', auth.isAuthenticated, function(req, res) {
+router.get('/:db/_changes', auth, function(req, res) {
   var user = basicAuth(req);
   var query = req.query || {};
   if (query.filter) {

--- a/lib/routes/delete-document.js
+++ b/lib/routes/delete-document.js
@@ -8,7 +8,7 @@ var express = require('express'),
   auth = require('../auth');
 
 // Delete a document
-router.delete('/:db/:id', auth.isAuthenticated, function(req, res) {
+router.delete('/:db/:id', auth, function(req, res) {
   var user = basicAuth(req);
   app.db.get(req.params.id, req.query.rev, function(err, data) {
     // We need a rev in order to delete
@@ -25,12 +25,12 @@ router.delete('/:db/:id', auth.isAuthenticated, function(req, res) {
     }
 
     if (!data[app.metaKey]) {
-      return auth.unauthorized(res);
+      return utils.unauthorized(res);
     }
     var authfield = data[app.metaKey].auth;
     if (!authfield.users) {
       console.error('Bad auth format for doc id:', data._id);
-      return auth.unauthorized(res);
+      return utils.unauthorized(res);
     }
 
     if (authfield.users.indexOf(user.name) >= 0) {
@@ -44,7 +44,7 @@ router.delete('/:db/:id', auth.isAuthenticated, function(req, res) {
         }
       );
     } else {
-      return auth.unauthorized(res);
+      return utils.unauthorized(res);
     }
   });
 });

--- a/lib/routes/delete-document.js
+++ b/lib/routes/delete-document.js
@@ -3,13 +3,12 @@
 var express = require('express'),
   router = express.Router(),
   app = require('../../app'),
-  basicAuth = require('basic-auth'),
   utils = require('../utils'),
   auth = require('../auth');
 
 // Delete a document
-router.delete('/:db/:id', auth, function(req, res) {
-  var user = basicAuth(req);
+router.delete('/:db/:id', auth.isAuthenticated(), function(req, res) {
+
   app.db.get(req.params.id, req.query.rev, function(err, data) {
     // We need a rev in order to delete
     if (!req.query.rev) {

--- a/lib/routes/delete-document.js
+++ b/lib/routes/delete-document.js
@@ -32,7 +32,7 @@ router.delete('/:db/:id', auth.isAuthenticated(), function(req, res) {
       return utils.unauthorized(res);
     }
 
-    if (authfield.users.indexOf(user.name) >= 0) {
+    if (authfield.users.indexOf(req.user.username) >= 0) {
       app.db.destroy(req.params.id, req.query.rev,
         function(err, data) {
           if (err) {

--- a/lib/routes/find.js
+++ b/lib/routes/find.js
@@ -11,7 +11,7 @@ var express = require('express'),
 // The user posts their query to /db/_find.
 // We modify their query so that it only
 // includes their documents.
-router.post('/:db/_find', auth.isAuthenticated, function(req, res) {
+router.post('/:db/_find', auth, function(req, res) {
   
   // Authenticate the documents requested
   var user = basicAuth(req);

--- a/lib/routes/find.js
+++ b/lib/routes/find.js
@@ -2,7 +2,6 @@
 
 var express = require('express'),
   router = express.Router(),
-  basicAuth = require('basic-auth'),
   app = require('../../app'),
   utils = require('../utils'),
   auth = require('../auth');
@@ -11,10 +10,9 @@ var express = require('express'),
 // The user posts their query to /db/_find.
 // We modify their query so that it only
 // includes their documents.
-router.post('/:db/_find', auth, function(req, res) {
+router.post('/:db/_find', auth.isAuthenticated(), function(req, res) {
   
   // Authenticate the documents requested
-  var user = basicAuth(req);
   var body = req.body;
   
   // ensure that the query contains no reference to our meta object
@@ -38,7 +36,7 @@ router.post('/:db/_find', auth, function(req, res) {
     };
     filter.$and[0][app.metaKey + '.auth.users'] = {
       $elemMatch: {
-        $eq: user.name
+        $eq: req.user.username
       }
     };
     body.selector = filter;

--- a/lib/routes/get-database.js
+++ b/lib/routes/get-database.js
@@ -6,7 +6,7 @@ var express = require('express'),
 	utils = require('../utils'),
 	auth = require('../auth');
 
-router.get('/:db', auth.isAuthenticated, function(req, res) {
+router.get('/:db', auth, function(req, res) {
   app.db.get('', function(err, data) {
     if (err) {
       utils.sendError(err, res);

--- a/lib/routes/get-database.js
+++ b/lib/routes/get-database.js
@@ -6,7 +6,7 @@ var express = require('express'),
 	utils = require('../utils'),
 	auth = require('../auth');
 
-router.get('/:db', auth, function(req, res) {
+router.get('/:db', auth.isAuthenticated(), function(req, res) {
   app.db.get('', function(err, data) {
     if (err) {
       utils.sendError(err, res);

--- a/lib/routes/get-document.js
+++ b/lib/routes/get-document.js
@@ -7,7 +7,7 @@ var express = require('express'),
   utils = require('../utils'),
   auth = require('../auth');
 
-router.get('/:db/:id', auth.isAuthenticated, function(req, res) {
+router.get('/:db/:id', auth, function(req, res) {
   // 1. Get the document from the db
   // 2. Validate that the user has access
   // 3. return the document with the auth information stripped out
@@ -19,17 +19,17 @@ router.get('/:db/:id', auth.isAuthenticated, function(req, res) {
     var user = basicAuth(req);
 
     if (!data[app.metaKey]) {
-      return auth.unauthorized(res);
+      return utils.unauthorized(res);
     }
     var authfield = data[app.metaKey].auth;
     if (!authfield.users) {
       console.error('Bad auth format for doc id:', data._id);
-      return auth.unauthorized(res);
+      return utils.unauthorized(res);
     }
     if (authfield.users.indexOf(user.name) >= 0) {
       utils.stripAndSendJSON(data, res);
     } else {
-      return auth.unauthorized(res);
+      return utils.unauthorized(res);
     }
   });
 });

--- a/lib/routes/get-document.js
+++ b/lib/routes/get-document.js
@@ -3,11 +3,10 @@
 var express = require('express'),
   router = express.Router(),
   app = require('../../app'),
-  basicAuth = require('basic-auth'),
   utils = require('../utils'),
   auth = require('../auth');
 
-router.get('/:db/:id', auth, function(req, res) {
+router.get('/:db/:id', auth.isAuthenticated(), function(req, res) {
   // 1. Get the document from the db
   // 2. Validate that the user has access
   // 3. return the document with the auth information stripped out
@@ -16,7 +15,6 @@ router.get('/:db/:id', auth, function(req, res) {
       utils.sendError(err, res);
       return;
     }
-    var user = basicAuth(req);
 
     if (!data[app.metaKey]) {
       return utils.unauthorized(res);

--- a/lib/routes/get-document.js
+++ b/lib/routes/get-document.js
@@ -24,7 +24,7 @@ router.get('/:db/:id', auth.isAuthenticated(), function(req, res) {
       console.error('Bad auth format for doc id:', data._id);
       return utils.unauthorized(res);
     }
-    if (authfield.users.indexOf(user.name) >= 0) {
+    if (authfield.users.indexOf(req.user.username) >= 0) {
       utils.stripAndSendJSON(data, res);
     } else {
       return utils.unauthorized(res);

--- a/lib/routes/get-root.js
+++ b/lib/routes/get-root.js
@@ -2,11 +2,10 @@
 
 var express = require('express'),
   router = express.Router(),
-  app = require('../../app'),
-  request = require('request');
+  app = require('../../app');
 
 router.get('/', function(req, res) {
-  request(app.serverURL).pipe(res);
+  app.db.info().pipe(res);
 });
 
 module.exports = router;

--- a/lib/routes/insert-document.js
+++ b/lib/routes/insert-document.js
@@ -3,19 +3,17 @@
 var express = require('express'),
 	router = express.Router(),
 	app = require('../../app'),
-	basicAuth = require('basic-auth'),
 	utils = require('../utils'),
 	auth = require('../auth');
 
 // Insert a document
-router.put('/:db/:id', auth, function(req, res) {
+router.put('/:db/:id', auth.isAuthenticated(), function(req, res) {
 
   // 1. Read the new doc
   // 2. Add auth information, user has access
   // 3. Write the doc, return the database response
   var doc = req.body;
-  var user = basicAuth(req);
-  doc[app.metaKey] = {auth: {users: [user.name], groups: []}};
+  doc[app.metaKey] = {auth: {users: [req.user.username], groups: []}};
 
   utils.writeDoc(app.db, doc, req, res);
 });

--- a/lib/routes/insert-document.js
+++ b/lib/routes/insert-document.js
@@ -8,7 +8,7 @@ var express = require('express'),
 	auth = require('../auth');
 
 // Insert a document
-router.put('/:db/:id', auth.isAuthenticated, function(req, res) {
+router.put('/:db/:id', auth, function(req, res) {
 
   // 1. Read the new doc
   // 2. Add auth information, user has access

--- a/lib/routes/post-index.js
+++ b/lib/routes/post-index.js
@@ -16,9 +16,6 @@ var express = require('express'),
 
 router.post('/:db/_index', auth, function(req, res) {
   
-  // Authenticate the documents requested
-  var user = basicAuth(req);
-  
   // extract the body
   var body = req.body;
   if (body && utils.isArray(body.index.fields) && 
@@ -43,7 +40,7 @@ router.post('/:db/_index', auth, function(req, res) {
 */
 
 // don't allow the creation of indexes via Envoy API
-router.post('/:db/_index', auth, function(req, res) { 
+router.post('/:db/_index', auth.isAuthenticated(), function(req, res) { 
   var err = {
     statusCode: 404,
     error: 'Not Found',

--- a/lib/routes/post-index.js
+++ b/lib/routes/post-index.js
@@ -2,8 +2,6 @@
 
 var express = require('express'),
   router = express.Router(),
-  basicAuth = require('basic-auth'),
-  app = require('../../app'),
   utils = require('../utils'),
   auth = require('../auth');
 
@@ -16,7 +14,7 @@ var express = require('express'),
 
 **** Removed for now - see issue #31 ****
 
-router.post('/:db/_index', auth.isAuthenticated, function(req, res) {
+router.post('/:db/_index', auth, function(req, res) {
   
   // Authenticate the documents requested
   var user = basicAuth(req);
@@ -45,7 +43,7 @@ router.post('/:db/_index', auth.isAuthenticated, function(req, res) {
 */
 
 // don't allow the creation of indexes via Envoy API
-router.post('/:db/_index', auth.isAuthenticated, function(req, res) { 
+router.post('/:db/_index', auth, function(req, res) { 
   var err = {
     statusCode: 404,
     error: 'Not Found',

--- a/lib/routes/revs-diff.js
+++ b/lib/routes/revs-diff.js
@@ -59,7 +59,7 @@ function badDocsByKeys(idlist, username, callback/*(err, bad)*/) {
 // The Cloudant/Nano library does not support the revsDiff API end point
 // directly, so we use the cloudant.request() call to roll our own.
 
-router.post('/:db/_revs_diff', auth.isAuthenticated, function(req, res) {
+router.post('/:db/_revs_diff', auth, function(req, res) {
   // Authenticate the documents requested
   var user = basicAuth(req);
   badDocsByKeys(Object.keys(req.body), user.name, function(err, inaccessible) {

--- a/lib/routes/revs-diff.js
+++ b/lib/routes/revs-diff.js
@@ -2,7 +2,6 @@
 
 var express = require('express'),
   router = express.Router(),
-  basicAuth = require('basic-auth'),
   app = require('../../app'),
   utils = require('../utils'),
   auth = require('../auth'),
@@ -59,10 +58,9 @@ function badDocsByKeys(idlist, username, callback/*(err, bad)*/) {
 // The Cloudant/Nano library does not support the revsDiff API end point
 // directly, so we use the cloudant.request() call to roll our own.
 
-router.post('/:db/_revs_diff', auth, function(req, res) {
+router.post('/:db/_revs_diff', auth.isAuthenticated(), function(req, res) {
   // Authenticate the documents requested
-  var user = basicAuth(req);
-  badDocsByKeys(Object.keys(req.body), user.name, function(err, inaccessible) {
+  badDocsByKeys(Object.keys(req.body), req.user.username, function(err, inaccessible) {
     if (err) {
       utils.sendError(err, res);
       return;

--- a/lib/routes/update-document.js
+++ b/lib/routes/update-document.js
@@ -8,7 +8,7 @@ var express = require('express'),
   auth = require('../auth');
 
 // Update a document
-router.post('/:db/:id', auth.isAuthenticated, function(req, res) {
+router.post('/:db/:id', auth, function(req, res) {
 
   // 1. Get the document from the db
   // 2. Validate that the user has access
@@ -23,13 +23,13 @@ router.post('/:db/:id', auth.isAuthenticated, function(req, res) {
 
     if (!data[app.metaKey]) {
       console.error('Unexpected doc: ', JSON.stringify(data, null, 4));
-      return auth.unauthorized(res);
+      return utils.unauthorized(res);
     }
 
     var authfield = data[app.metaKey].auth;
     if (!authfield.users) {
       console.error('Bad auth format for doc id:', data._id);
-      return auth.unauthorized(res);
+      return utils.unauthorized(res);
     }
 
     if (authfield.users.indexOf(user.name) >= 0) {
@@ -40,7 +40,7 @@ router.post('/:db/:id', auth.isAuthenticated, function(req, res) {
       doc._rev = data._rev;
       utils.writeDoc(app.db, doc, req, res);
     } else {
-      return auth.unauthorized(res);
+      return utils.unauthorized(res);
     }
   });
 });

--- a/lib/routes/update-document.js
+++ b/lib/routes/update-document.js
@@ -2,19 +2,17 @@
 
 var express = require('express'),
   router = express.Router(),
-  basicAuth = require('basic-auth'),
   app = require('../../app'),
   utils = require('../utils'),
   auth = require('../auth');
 
 // Update a document
-router.post('/:db/:id', auth, function(req, res) {
+router.post('/:db/:id', auth.isAuthenticated(), function(req, res) {
 
   // 1. Get the document from the db
   // 2. Validate that the user has access
   // 3. Write the doc with the auth information added back in,
   //  return the database response
-  var user = basicAuth(req);
   app.db.get(req.params.id, function(err, data) {
     if (err) {
       utils.sendError(err, res);
@@ -32,7 +30,7 @@ router.post('/:db/:id', auth, function(req, res) {
       return utils.unauthorized(res);
     }
 
-    if (authfield.users.indexOf(user.name) >= 0) {
+    if (authfield.users.indexOf(req.user.username) >= 0) {
       var doc = req.body;
       doc[app.metaKey] = {'auth': authfield};
       // TODO - should we require the user to send the current _rev

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -143,7 +143,7 @@ var dmp = function (msg, obj) {
 };
 
 var unauthorized = function (res) {
-  res.set('WWW-Authenticate', 'Basic realm=Authorization Required');
+//  res.set('WWW-Authenticate', 'Basic realm=Authorization Required');
   return res.sendStatus(401);
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var app = require('../app'),
+  crypto = require('crypto'),
   stream = require('stream');
 
 
@@ -141,6 +142,15 @@ var dmp = function (msg, obj) {
   console.log(msg, JSON.stringify(obj, null, 2));
 };
 
+var unauthorized = function (res) {
+  res.set('WWW-Authenticate', 'Basic realm=Authorization Required');
+  return res.sendStatus(401);
+}
+
+var sha1 = function(string) {
+  return crypto.createHash('sha1').update(string).digest('hex');
+}
+
 module.exports = {
   isObject: isObject,
   isArray: isArray,
@@ -150,5 +160,7 @@ module.exports = {
   writeDoc: writeDoc,
   authRemover: authRemover,
   liner: liner,
-  dmp: dmp
+  dmp: dmp,
+  unauthorized: unauthorized,
+  sha1: sha1
 };

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "express-session": "^1.13.0",
     "morgan": "^1.6.1",
     "passport": "^0.3.2",
+    "passport-facebook": "^2.1.1",
     "passport-google-oauth": "^1.0.0",
     "passport-http": "^0.3.0",
     "underscore": "^1.8.3"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,10 @@
     "compression": "^1.6.2",
     "events": "^1.1.0",
     "express": "^4.13.4",
+    "express-session": "^1.13.0",
     "morgan": "^1.6.1",
     "passport": "^0.3.2",
+    "passport-google-oauth": "^1.0.0",
     "passport-http": "^0.3.0",
     "underscore": "^1.8.3"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "async": "^1.5.2",
-    "basic-auth": "^1.0.3",
     "body-parser": "^1.14.2",
     "cf-deployment-tracker-client": "^0.1.1",
     "cfenv": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "passport-github2": "^0.1.10",
     "passport-google-oauth": "^1.0.0",
     "passport-http": "^0.3.0",
+    "passport-twitter": "^1.0.4",
     "underscore": "^1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "cloudant": "git@github.com:cloudant/nodejs-cloudant.git",
     "compression": "^1.6.2",
     "events": "^1.1.0",
-    "express": "^4.13.3",
+    "express": "^4.13.4",
     "morgan": "^1.6.1",
+    "passport": "^0.3.2",
+    "passport-http": "^0.3.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
@@ -49,8 +51,8 @@
   "bugs": {
     "url": "https://github.com/cloudant-labs/envoy/issues"
   },
-  "bin" : { 
-    "envoy" : "./bin/www" 
+  "bin": {
+    "envoy": "./bin/www"
   },
   "engines": {
     "node": ">=4.2.0"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "morgan": "^1.6.1",
     "passport": "^0.3.2",
     "passport-facebook": "^2.1.1",
+    "passport-github2": "^0.1.10",
     "passport-google-oauth": "^1.0.0",
     "passport-http": "^0.3.0",
     "underscore": "^1.8.3"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "body-parser": "^1.14.2",
     "cf-deployment-tracker-client": "^0.1.1",
     "cfenv": "^1.0.3",
-    "cloudant": "git@github.com:cloudant/nodejs-cloudant.git",
+    "cloudant": "https://github.com/cloudant/nodejs-cloudant.git",
     "compression": "^1.6.2",
     "events": "^1.1.0",
     "express": "^4.13.4",
@@ -59,6 +59,6 @@
     "envoy": "./bin/www"
   },
   "engines": {
-    "node": ">=4.2.0"
+    "node": "4.4.0"
   }
 }

--- a/test/_node_setup.js
+++ b/test/_node_setup.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var auth = require('../lib/auth');
-
 process.env.MBAAS_DATABASE_NAME = 
   (process.env.MBAAS_DATABASE_NAME || 'mbaas') +
 	(new Date().getTime());
@@ -30,4 +28,4 @@ before(function(done) {
 
 global.testUtils = require('./utils.js');
 global.username = 'foo';
-global.password = auth.sha1(global.username);
+global.password = require('../lib/utils').sha1(global.username);

--- a/test/bulk-docs.js
+++ b/test/bulk-docs.js
@@ -2,7 +2,6 @@
 /* globals testUtils */
 
 var assert = require('assert'),
-  auth = require('../lib/auth'),
   PouchDB = require('pouchdb'),
   chance = require('chance')();
 

--- a/test/bulk-get.js
+++ b/test/bulk-get.js
@@ -2,7 +2,7 @@
 /* globals testUtils */
 
 var assert = require('assert'),
-  auth = require('../lib/auth'),
+  utils = require('../lib/utils'),
   PouchDB = require('pouchdb');
 
 describe('bulk_get', function () {
@@ -10,7 +10,7 @@ describe('bulk_get', function () {
     this.timeout(10000);
     var docCount = 5;
     var docs = testUtils.makeDocs(docCount),
-      remoteURL = testUtils.url('bob', auth.sha1('bob')),
+      remoteURL = testUtils.url('bob', utils.sha1('bob')),
       remote = new PouchDB(remoteURL);
 
     return remote.bulkDocs(docs).then(function (response) {

--- a/test/changes.js
+++ b/test/changes.js
@@ -2,7 +2,6 @@
 /* globals testUtils */
 
 var assert = require('assert'),
-  auth = require('../lib/auth'),
   PouchDB = require('pouchdb');
 
 describe('changes', function () {

--- a/test/query.js
+++ b/test/query.js
@@ -2,7 +2,6 @@
 /* globals testUtils */
 
 var assert = require('assert'),
-  auth = require('../lib/auth'),
   PouchDB = require('pouchdb'),
   app = require('../app'),
   remoteURL = testUtils.uniqueUserUrl(),

--- a/test/revs-diff.js
+++ b/test/revs-diff.js
@@ -2,7 +2,6 @@
 /* globals testUtils */
 
 var assert = require('assert'),
-  auth = require('../lib/auth'),
   chance = require('chance')(),
   PouchDB = require('pouchdb');
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -3,7 +3,7 @@
 
 var PouchDB = require('pouchdb'),
   assert = require('assert'),
-  auth = require('../lib/auth');
+  utils = require('../lib/utils');
 
 // Generate a bunch of documents, and store those in a local
 // PouchDB. Kick off a push replication, and then query remote
@@ -23,7 +23,7 @@ describe('test single user sync', function () {
     this.timeout(10000);
 
     var username = 'push_repl_test';
-    var remoteURL = testUtils.url(username, auth.sha1(username));
+    var remoteURL = testUtils.url(username, utils.sha1(username));
 
     var local = new PouchDB(dbs.local);
     var remote = new PouchDB(remoteURL);
@@ -47,7 +47,7 @@ describe('test single user sync', function () {
     this.timeout(10000);
 
     var username = 'pull_repl_test';
-    var remoteURL = testUtils.url(username, auth.sha1(username));
+    var remoteURL = testUtils.url(username, utils.sha1(username));
 
     var local = new PouchDB(dbs.local);
     var remote = new PouchDB(remoteURL);
@@ -67,7 +67,7 @@ describe('test single user sync', function () {
     this.timeout(10000);
 
     var username = 'multi_repl_test';
-    var remoteURL = testUtils.url(username, auth.sha1(username));
+    var remoteURL = testUtils.url(username, utils.sha1(username));
 
     var client1 = new PouchDB(dbs.local);
     var client2 = new PouchDB(dbs.secondary);

--- a/test/utils.js
+++ b/test/utils.js
@@ -3,8 +3,7 @@
 var chance = require('chance')(),
   url = require('url'),
   PouchDB = require('pouchdb'),
-  env = require('../lib/env.js'),
-  auth = require('../lib/auth');
+  env = require('../lib/env.js');
 
 var testUtils = {};
 var userCount = 0;
@@ -38,7 +37,7 @@ testUtils.url = function(user, password) {
 
 testUtils.uniqueUserUrl = function() {
   var username = 'user' + userCount++;
-  return testUtils.url(username, auth.sha1(username));
+  return testUtils.url(username, require('../lib/utils').sha1(username));
 };
 
 


### PR DESCRIPTION
The original `basic` authentication mode is retained by default so that first-time users can try Envoy out quickly.

But by switching authentication modes (`AUTH_STRATEGY=google`), we can switch Envoy to use Google OAuth2. 

This uses the [PassportJS](http://passportjs.org/) which has authentication modules for many third-party authentication brokers - Facebook, Twitter, LinkedIn, Twitter etc. I decided to modularise the authentication a bit - to create a new one just add a file to `lib/auth` and use `AUTH_STRATEGY` to select the one you want at run time.

The tests were all set up for basic auth so they remain largely unchanged. 

