### PR TITLE
Source cloudant-nodejs via http instead of ssh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,19 @@
 language: node_js
+
 node_js:
-  - "stable"
+  - "5"
+
 git:
   depth: 30
+
 sudo:
   false
+
 env:
   global: 
     - secure: "d8ankESjYR+Edd+MNeWNlvqX+YxJJbTHOeRMajmXtoZ5gxES0pftP4J6LPkS0O6HuP4FChZWD2BiIOWR/J5sO0JARBUrFX/M/kKKH9SaIffSijYcmxmdG/w6rReu3eSwTqQ3uS7MYs6/YiY+BIUuBXujIMcUIVJI7CPusIJ/S3s="
     - PORT=8080
     - MBAAS_DATABASE_NAME='mbaas'
+
 script:
   npm run mocha

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ env:
     - PORT=8080
     - MBAAS_DATABASE_NAME='mbaas'
 script:
-  npm run test
+  npm run mocha

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "body-parser": "^1.14.2",
     "cf-deployment-tracker-client": "^0.1.1",
     "cfenv": "^1.0.3",
-    "cloudant": "git@github.com:cloudant/nodejs-cloudant.git",
+    "cloudant": "https://github.com/cloudant/nodejs-cloudant.git",
     "compression": "^1.6.2",
     "events": "^1.1.0",
     "express": "^4.13.3",


### PR DESCRIPTION
We don't want `npm install` to require a valid GitHub SSH key - this should fix it.