### PR TITLE
Use CouchDB docker image for Travis tests instead of Cloudant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,15 @@ git:
 sudo:
   false
 
+services:
+  - docker
+
 env:
   global: 
-    - secure: "WC5MSd2qhJ4U//9pEo2n7gQUxg5zBiPMnHA8aeLUWrqb5SvWkWFs8KAx14iZeEcdGHj/VCFm9U9ZEWrEdL0yteBmYYVtNwfoea9sr/tH9w0Ii1iGIObSwwHyeo8Eay4bnuLQTmlz1Js/J9/w9XUwivJwy0YjdINwWQJjFv6YZUZDp0LIpNEHgRHfT3sunuWGBCJnCuJxHnARXWoOT2bn69Jx/GD3bwVVX5nnC4a3rchD0s0bDjx7OPfJv26kjfp+0NfrSKBQGm50nw04gSue6cuDkFZnXzIQpn4DP8Ilwne52II8J4o09osnJHUejEl/mPQGeTy3nA2bCNruWlinvhcGufVYqIfllXb3fATEyhJttQNJ23RY7ZivjysaahruWSluDK/275av3y+Vgc4FCzPyvr9B31wqtSPm3tY/ZBnsj+FYsU8MPRw0dS4IhVjvI6oNOXoUcM8+551CWWFAzqIAnbH0cPTNMTBxPN9wb7Qbxy9Ovum7avxFGgMY7T8PXgDUTchVS9DRwn9dpSu9VS6J0/nBMBpKkVVUqY1PzQuoLqme/glyrKYdmxegI7z5hqesaxxU8a6oq2FUEH6xCobxV6EMbK1UAWtyJ2w00hX/aXlAOonNQRXT8zaO8kPjBHP3NP7cfViMz8bGiZnt5hoNDr2HSn/QbjXkILBC6uw="
-    - PORT=8080
-    - MBAAS_DATABASE_NAME='mbaas'
+  - PORT=8080
+  - MBAAS_DATABASE_NAME='mbaas'
+  matrix:
+  - COUCH_HOST=http://127.0.0.1:3001
 
 script:
-  npm run mocha
+  npm run test

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start": "node ./bin/www",
     "jshint": "jshint -c .jshintrc lib/",
     "mocha": "./node_modules/.bin/mocha test -t 20000",
-    "test": "npm run jshint; npm run mocha"
+    "test": "bash scripts/run_couchdb_on_travis.sh; npm run mocha"
   },
   "dependencies": {
     "async": "^1.5.2",

--- a/scripts/run_couchdb_on_travis.sh
+++ b/scripts/run_couchdb_on_travis.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if [ ! -z $TRAVIS ]; then
+	# Install CouchDB Master
+	docker run --ulimit nofile=2048:2048 -d -p 3001:5984 klaemo/couchdb:2.0-dev --with-haproxy \
+	    --with-admin-party-please -n 1
+	COUCH_PORT=3001
+
+	# wait for couchdb to start
+	while [ '200' != $(curl -s -o /dev/null -w %{http_code} http://127.0.0.1:${COUCH_PORT}) ]; do
+	  echo waiting for couch to load... ;
+	  sleep 1;
+	done
+fi


### PR DESCRIPTION
Rather than using Cloudant's docker image, this uses
the CouchDB 2.0/master one (similar to PouchDB).

We don't currently rely on any Cloudant-specific features and
this image will be updated more regularly than the Cloudant one,
which matches the currently supported version of Cloudant Local.