### PR TITLE
simulates _bulk_get if Cloudant does not support it

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,6 +80,7 @@ async.series(
     init.verifyDB,
     init.verifySecurityDoc,
     init.installSystemViews,
+    init.detectBulkGet,
     auth.init
   ],
 

--- a/lib/init.js
+++ b/lib/init.js
@@ -147,3 +147,16 @@ function verifySecurityDoc(callback/*(err, result)*/) {
 }
 
 exports.verifySecurityDoc = verifySecurityDoc;
+
+exports.detectBulkGet = function (callback) {
+  app.cloudant.request({
+    db: app.dbName,
+    method: 'get',
+    path: '_bulk_get'
+  }, function(err, data) {
+    // if we get a 405 back then _bulk_get exists!
+    app.bulkGet = (err && err.statusCode === 405);
+    var str = app.bulkGet?'bulkGet detected':'bulkGet not ndetected - simulating'
+    callback(null, '[OK]  ' + str);
+  })
+};

--- a/lib/routes/bulk-get.js
+++ b/lib/routes/bulk-get.js
@@ -25,6 +25,8 @@ var express = require('express'),
   app = require('../../app'),
   auth = require('../auth'),
   access = require('../access'),
+  uuid = require('uuid'),
+  async = require('async'),
   utils = require('../utils');
 
 // Pouch does this to check it exists
@@ -36,7 +38,53 @@ router.get('/:db/_bulk_get', auth.isAuthenticated, function(req, res) {
   }).pipe(res);
 });
 
-router.post('/:db/_bulk_get', auth.isAuthenticated, function(req, res) {
+// simulate POST /db/_bulk_get with lots of GETs
+var simulatedBulkGet = function(req,res) {
+    if (req.body && req.body.docs) {
+
+    // add ownerids to incoming ids
+    req.body.docs = req.body.docs.map(function(doc) {
+      doc.id = access.addOwnerId(doc.id, req.session.user.name);
+      return doc;
+    });
+    
+    // build up an array of individual get requests to be made in parallel
+    var tasks = [];
+    req.body.docs.forEach(function(doc) {
+      (function(d){
+        tasks.push(function(callback) {
+          var opts = req.query;
+          opts.revs = true;
+          app.db.get(d.id, opts, function(err, data) {
+            if (err) {
+              data = { id: d.id, rev: opts.rev, error: err.error,  }
+            }
+            var result = { id: access.removeOwnerId(d.id), docs:[ ] };
+            var item = {};
+            if (data.error) {
+              item.error = access.strip(data);
+            } else {
+              item.ok = access.strip(data);
+            }
+            result.docs.push(item);
+            callback(null, result);
+          });
+        });
+      })(doc);
+    });
+    
+    // run the tasks in parallel (up to 10 at a time)
+    async.parallelLimit(tasks, 10, function(err, data) {
+      res.send({results: data});
+    });
+
+  } else {
+    res.status(400).send({error:'missing docs parameter'});
+  }
+};
+
+// use real POST /db/_bulk_get
+var realBulkGet = function(req, res) {
   // add ownerids to incoming ids
   if (req.body && req.body.docs) {
     req.body.docs = req.body.docs.map(function(doc) {
@@ -68,6 +116,15 @@ router.post('/:db/_bulk_get', auth.isAuthenticated, function(req, res) {
       return stripped;
     })});
   });
+};
+
+// use real or simulated bulk_get
+router.post('/:db/_bulk_get',auth.isAuthenticated, function(req, res) {
+  if (app.bulkGet) {
+    realBulkGet(req, res);
+  } else {
+    simulatedBulkGet(req, res);
+  }
 });
 
 module.exports = router;


### PR DESCRIPTION
On startup, Envoy looks to see if the Cloudant it is connected to supports the newish `_bulk_get` endpoint. If it doesn't, it simulates it. 

In coming requests to `POST /db/_bulk_get` become many individual GET requests between Envoy & Cloudant. 

Based on @willholley's idea in issue #80 