### PR TITLE
allow Envoy to be supplied custom routes to add to its Express routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,46 @@ By default Envoy uses the [Express Session](https://github.com/expressjs/session
     });
     var opts = {
       sessionHandler :sessionHandler,
+      port: 9000
+    };
+    var envoy = require('cloudant-envoy')(opts);
+```
+
+### Static files
+
+You can get Envoy to server out static files for you. Simply pass in a 'static' option or use the ENVOY_STATIC environment variable:
+
+```js
+    var opts = {
       port: 9000,
       static: path.join(__dirname, './public')
     };
     var envoy = require('cloudant-envoy')(opts);
+```
+
+### Custom routes
+
+You can supply your own custom routes to Envoy too:
+
+```js
+var express = require('express'),
+  router = express.Router();
+
+// my custom route
+router.get('/myroute', function(req, res) {
+  res.send({ok:true});
+});
+
+var opts = {
+    databaseName: dbName,
+    port: appEnv.port,
+    logFormat: 'dev',
+    production: true,
+    static: path.join(__dirname, './public'),
+    router: router
+};
+
+var envoy = require('../envoy')(opts);
 ```
 
 ## Debugging

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ var opts = {
     router: router
 };
 
-var envoy = require('../envoy')(opts);
+var envoy = require('envoy')(opts);
 ```
 
 ## Debugging

--- a/app.js
+++ b/app.js
@@ -45,9 +45,13 @@ module.exports = function(opts) {
     app.use(morgan(app.opts.logFormat));
   }
 
-
   function main() {
     
+    // plug in custom routes
+    if (opts.router) {
+      app.use(opts.router);
+    }
+
     var production = (app.opts.production && app.opts.production === 'true');
     if (app.opts.static) {
       console.log('[OK]  Serving out directory: ' + app.opts.static);

--- a/app.js
+++ b/app.js
@@ -48,8 +48,8 @@ module.exports = function(opts) {
   function main() {
     
     // plug in custom routes
-    if (opts.router) {
-      app.use(opts.router);
+    if (app.opts.router) {
+      app.use(app.opts.router);
     }
 
     var production = (app.opts.production && app.opts.production === 'true');

--- a/lib/env.js
+++ b/lib/env.js
@@ -12,7 +12,8 @@ function getCredentials(startOpts) {
     port: process.env.PORT || startOpts.port || 8000,
     url: null,
     production: process.env.PRODUCTION || startOpts.production || false,
-    static: process.env.ENVOY_STATIC || startOpts.static || null
+    static: process.env.ENVOY_STATIC || startOpts.static || null,
+    router: startOpts.router || null
   };
 
   if (process.env.VCAP_SERVICES) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudant-envoy",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A mobile backend shim to Cloudant",
   "contributors": [
     "Stefan Kruger <stefan.kruger@gmail.com>",


### PR DESCRIPTION
Make Envoy properly extensible by allowing custom Express routes to be supplied to supplement or override existing routes. i.e a third-party app can pass Envoy

- its static directory of files
- its list of routes

and Envoy will add them to its routing list.