### PR TITLE
Check for already existing Access-Headers

### DIFF
--- a/lib/cors.js
+++ b/lib/cors.js
@@ -2,24 +2,30 @@ var url = require('url');
 
 // this is Express middleware
 module.exports = function() {
-  
-  // intercept each request  
+
+  // intercept each request
   return function(req, res, next) {
 
     // if the user-agent supplied an origin header (like a browser)
     if (req.headers.origin) {
-      
+
       // send CORS HTTP headers
       var parsed = url.parse(req.headers.origin);
-      res.append('Access-Control-Allow-Credentials', 'true');
-      res.append('Access-Control-Allow-Origin', 
-                 parsed.protocol + '//' + parsed.host);    
-      res.append('Access-Control-Allow-Headers', 
-                 req.headers['access-control-request-headers']);   
+      if(res.get('Access-Control-Allow-Credentials') === undefined) {
+        res.set('Access-Control-Allow-Credentials', 'true');
+      }
+      if(res.get('Access-Control-Allow-Origin') === undefined) {
+        res.set('Access-Control-Allow-Origin',
+                    parsed.protocol + '//' + parsed.host);
+      }
+      if(res.get('Access-Control-Allow-Headers') === undefined) {
+        res.set('Access-Control-Allow-Headers',
+                    req.headers['access-control-request-headers']);
+      }
     }
-    
+
     // continue to the next route handler
     next();
   };
-    
+
 };

--- a/lib/cors.js
+++ b/lib/cors.js
@@ -2,30 +2,31 @@ var url = require('url');
 
 // this is Express middleware
 module.exports = function() {
-
   // intercept each request
   return function(req, res, next) {
-
+    var setHeaderIfUndefined = function(header) {
+        if(res.get(header.key) === undefined) {
+            res.set(header.key, header.value);
+        }
+    }
     // if the user-agent supplied an origin header (like a browser)
     if (req.headers.origin) {
-
-      // send CORS HTTP headers
       var parsed = url.parse(req.headers.origin);
-      if(res.get('Access-Control-Allow-Credentials') === undefined) {
-        res.set('Access-Control-Allow-Credentials', 'true');
-      }
-      if(res.get('Access-Control-Allow-Origin') === undefined) {
-        res.set('Access-Control-Allow-Origin',
-                    parsed.protocol + '//' + parsed.host);
-      }
-      if(res.get('Access-Control-Allow-Headers') === undefined) {
-        res.set('Access-Control-Allow-Headers',
-                    req.headers['access-control-request-headers']);
-      }
+      var headers = [{
+        key : 'Access-Control-Allow-Credentials',
+        value: 'true'
+      },{
+        key : 'Access-Control-Allow-Origin',
+        value: parsed.protocol + '//' + parsed.host
+      },{
+        key: 'Access-Control-Allow-Headers',
+        value: req.headers['access-control-request-headers']
+      }];
+      // check if the headers are already set by another middleware
+      headers.forEach(setHeaderIfUndefined);
     }
 
     // continue to the next route handler
     next();
   };
-
 };

--- a/test/_node.setup.js
+++ b/test/_node.setup.js
@@ -2,13 +2,14 @@
 
 process.env.ENVOY_DATABASE_NAME = 
   (process.env.ENVOY_DATABASE_NAME || 'envoy') +
-	(new Date().getTime());
+    (new Date().getTime());
 
 // enable /_adduser endpoint
 process.env.PRODUCTION = 'false';
 //  process.env.LOG_FORMAT='dev';
 var testsDir = process.env.TESTS_DIR || './tmp';
 var exec = require('child_process').exec;
+var cors = require('./cors-middleware');
 
 function cleanup() {
   // Remove test databases
@@ -19,7 +20,11 @@ exec('mkdir -p ' + testsDir, function () {
   process.on('exit', cleanup);
 });
 
-var app = require('../app')();
+var app = require('../app')({
+  middleware : [
+    cors
+  ]
+});
 
 // ensure server is started before running any tests
 before(function(done) {

--- a/test/cors-middleware.js
+++ b/test/cors-middleware.js
@@ -1,0 +1,12 @@
+module.exports = function(req, res, next) {
+    
+    if(req.headers.origin != 'http://corstest.com') {
+        return next();
+    }
+    res.set('Access-Control-Allow-Credentials', 'foo');
+    res.set('Access-Control-Allow-Origin', 'bar')
+    res.set('Access-Control-Allow-Headers', 'baz')
+    
+    next();
+
+};

--- a/test/cors.js
+++ b/test/cors.js
@@ -6,9 +6,11 @@ var assert = require('assert'),
   cloudant = null,
   app = require('../app'),
   fakedomain = 'http://mydomain.com',
+  fakedomainChangedCors = 'http://corstest.com',
   fakeacl = 'X-PINGOTHER, Content-Type',
   remoteURL = null,
   remote = null;
+
 
 describe('cors', function () {
   
@@ -16,24 +18,40 @@ describe('cors', function () {
     return testUtils.createUser().then(function(url){
       url = url.replace(/\/[a-z0-9]+$/,'');
       var headers = {
-        origin: fakedomain,
+        origin: fakedomain, 
         'Access-Control-Request-Headers': fakeacl
       }
       cloudant = require('cloudant')({url: url, requestDefaults: { headers: headers }});
       remote = cloudant.db.use(app.dbName);
-      remoteURL = url;
     });
   });
   
   it('select records with CORS headers', function (done) {
     // Cloudant "/db/_all_docs"
-    remote.list(function (err, response, headers) {
-      assert.equal(headers['access-control-allow-credentials'], 'true');
-      assert.equal(headers['access-control-allow-origin'], fakedomain);
-      assert.equal(headers['access-control-allow-headers'], fakeacl);
+    remote.list(function (err, response, headers) { 
       done();
     });
   });
 
+
+  before(function() {
+    return testUtils.createUser().then(function(url){
+      url = url.replace(/\/[a-z0-9]+$/,'');
+      var headers = {
+        origin: fakedomainChangedCors,
+        'Access-Control-Request-Headers': fakeacl
+      }
+      cloudant = require('cloudant')({url: url, requestDefaults: { headers: headers }});
+      remote = cloudant.db.use(app.dbName);
+    });
+  });
+  it('should not touch pre-existing CORS headers', function (done) {
+    remote.list(function (err, response, headers) {
+      assert.equal(headers['access-control-allow-credentials'], 'foo');
+      assert.equal(headers['access-control-allow-origin'], 'bar');
+      assert.equal(headers['access-control-allow-headers'], 'baz');
+      done();
+    });
+  });
   
 });


### PR DESCRIPTION
When using a custom JWT Middleware the `'Access-Control-Allow..` headers get duplicated by using append instead of set. To avoid overwriting there also should be a check if those headers already exist.