### PR TITLE
Add missing reference to app to read metaKey

### DIFF
--- a/lib/plugins/access/meta.js
+++ b/lib/plugins/access/meta.js
@@ -1,6 +1,7 @@
 var stream = require('stream'),
   express = require('express'),
   auth = require('../../auth'),
+  app = require('../../../app'),
 	router = express.Router();
 
 // add custom route


### PR DESCRIPTION
The meta access plugin needs to import `app` because it uses `app.metaKey`. This fixes issue #175 