### PR TITLE
Envoy should not strip "id" field, only "_id"

### DIFF
--- a/lib/plugins/access/id.js
+++ b/lib/plugins/access/id.js
@@ -40,9 +40,6 @@ var strip = function(doc) {
   if (typeof doc === 'object' && doc._id) {
     doc._id = removeOwnerId(doc._id);    
   }
-  if (typeof doc === 'object' && doc.id) {
-    doc.id = removeOwnerId(doc.id);    
-  }
   return doc;
 };
 


### PR DESCRIPTION
The current access/id.js code strips **both** `id` and the `_id` field.  

There's no reason to do this, as `id` is not the same as `_id`.   Since `id` is not a reserved field, and there's no guarantee that it's the same as `_id`, it should not be changed.

In my case, id was a numeric field, and this was causing envoy to crash with "match is not a function"